### PR TITLE
Backport: Merge pull request #3883 from MaciekPytel/fix_antiaffinity

### DIFF
--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -22,9 +22,9 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 )
 
 // podInfo contains Pod and score that corresponds to how important it is to handle the pod first.

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -17,15 +17,14 @@ limitations under the License.
 package estimator
 
 import (
-	"fmt"
 	"sort"
-	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 )
 
 // podInfo contains Pod and score that corresponds to how important it is to handle the pod first.
@@ -75,7 +74,6 @@ func (estimator *BinpackingNodeEstimator) Estimate(
 		}
 	}()
 
-	newNodeNameTimestamp := time.Now()
 	newNodeNameIndex := 0
 
 	for _, podInfo := range podInfos {
@@ -92,7 +90,7 @@ func (estimator *BinpackingNodeEstimator) Estimate(
 		}
 		if !found {
 			// Add new node
-			newNodeName, err := estimator.addNewNodeToSnapshot(nodeTemplate, newNodeNameTimestamp, newNodeNameIndex)
+			newNodeName, err := estimator.addNewNodeToSnapshot(nodeTemplate, newNodeNameIndex)
 			if err != nil {
 				klog.Errorf("Error while adding new node for template to ClusterSnapshot; %v", err)
 				return 0
@@ -111,19 +109,17 @@ func (estimator *BinpackingNodeEstimator) Estimate(
 
 func (estimator *BinpackingNodeEstimator) addNewNodeToSnapshot(
 	template *schedulernodeinfo.NodeInfo,
-	nameTimestamp time.Time,
 	nameIndex int) (string, error) {
 
-	newNode := template.Node().DeepCopy()
-	newNode.Name = fmt.Sprintf("%s-%d-%d", newNode.Name, nameTimestamp.Unix(), nameIndex)
-	if newNode.Labels == nil {
-		newNode.Labels = make(map[string]string)
+	newNodeInfo := scheduler.DeepCopyTemplateNode(template, nameIndex)
+	var pods []*apiv1.Pod
+	for _, podTemplate := range newNodeInfo.Pods() {
+		pods = append(pods, podTemplate)
 	}
-	newNode.Labels["kubernetes.io/hostname"] = newNode.Name
-	if err := estimator.clusterSnapshot.AddNodeWithPods(newNode, template.Pods()); err != nil {
+	if err := estimator.clusterSnapshot.AddNodeWithPods(newNodeInfo.Node(), pods); err != nil {
 		return "", err
 	}
-	return newNode.Name, nil
+	return newNodeInfo.Node().Name, nil
 }
 
 // Calculates score for all pods and returns podInfo structure.

--- a/cluster-autoscaler/utils/scheduler/scheduler.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 // CreateNodeNameToInfoMap obtains a list of pods and pivots that list into a map where the keys are node names


### PR DESCRIPTION
Set different hostname label for upcoming nodes
--
EDIT: make change backwards compatible with breaking schedulernodeinfo to
schedulerframework change according to https://github.com/kubernetes/autoscaler/commit/73a5cdf928d3b04ac5cbc456a60d5eb084f9cbc1

Once we upgrade past the CA version that has this breaking change, we can grab the original CA patch upstream and apply it cleanly