### PR TITLE
compare each priority, if not found, throw warning

### DIFF
--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -132,10 +132,11 @@ func (p *priority) BestOptions(expansionOptions []expander.Option, nodeInfo map[
 		id := option.NodeGroup.Id()
 		found := false
 		for prio, nameRegexpList := range priorities {
-			if prio < maxPrio {
+			if !p.groupIDMatchesList(id, nameRegexpList) {
 				continue
 			}
-			if !p.groupIDMatchesList(id, nameRegexpList) {
+			found = true
+			if prio < maxPrio {
 				continue
 			}
 			if prio > maxPrio {
@@ -143,7 +144,7 @@ func (p *priority) BestOptions(expansionOptions []expander.Option, nodeInfo map[
 				best = nil
 			}
 			best = append(best, option)
-			found = true
+
 		}
 		if !found {
 			msg := fmt.Sprintf("Priority expander: node group %s not found in priority expander configuration. "+


### PR DESCRIPTION
Backport https://github.com/kubernetes/autoscaler/pull/3758 to our CA. 
This change fixes misleading log lines with the priority expander

`./hack/verify-all.sh -v` output:

```
Skipping ./hack/../hack/verify-all.sh
Verifying ./hack/../hack/verify-boilerplate.sh
SUCCESS
Verifying ./hack/../hack/verify-gofmt.sh
SUCCESS
Verifying ./hack/../hack/verify-golint.sh
SUCCESS
Verifying ./hack/../hack/verify-spelling.sh
SUCCESS
```

`make test-in-docker` output:

```
➜  cluster-autoscaler git:(bruno_batista--cluster-autoscaler-patch-cluster-autoscaler-1.19.2-airbnb3) make test-in-docker
rm -f cluster-autoscaler-amd64
docker build -t autoscaling-builder ../builder
[+] Building 32.7s (9/9) FINISHED                                                                                                                                                
 => [internal] load build definition from Dockerfile                                                                                                                        0.0s
 => => transferring dockerfile: 918B                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/golang:1.14                                                                                                              3.9s
 => [1/5] FROM docker.io/library/golang:1.14@sha256:1a7173b5b9a3af3e29a5837e0b2027e1c438fd1b83bbee8f221355087ad416d6                                                       18.0s
 => => resolve docker.io/library/golang:1.14@sha256:1a7173b5b9a3af3e29a5837e0b2027e1c438fd1b83bbee8f221355087ad416d6                                                        0.0s
 => => sha256:21a5635903d69da3c3d928ed429e3610eecdf878cbd763aabf5db9693016ffbb 7.03kB / 7.03kB                                                                              0.0s
 => => sha256:feab2c490a3cea21cc051ff29c33cc9857418edfa1be9966124b18abe1d5ae16 10.00MB / 10.00MB                                                                            1.7s
 => => sha256:1a7173b5b9a3af3e29a5837e0b2027e1c438fd1b83bbee8f221355087ad416d6 2.36kB / 2.36kB                                                                              0.0s
 => => sha256:6a39a02f74ffee82a169f2d836134236dc6f69e5946779da13deb3c7c6fedafd 1.79kB / 1.79kB                                                                              0.0s
 => => sha256:0ecb575e629cd60aa802266a3bc6847dcf4073aa2a6d7d43f717dd61e7b90e0b 50.40MB / 50.40MB                                                                            2.1s
 => => sha256:7467d1831b6947c294d92ee957902c3cd448b17c5ac2103ca5e79d15afb317c3 7.83MB / 7.83MB                                                                              1.8s
 => => sha256:f15a0f46f8c38f4ca7daecf160ba9cdb3ddeafda769e2741e179851cfaa14eec 51.83MB / 51.83MB                                                                            3.5s
 => => sha256:1517911a35d7939f446084c1d4c31afc552678e81b3450c2af998b57f72099c2 68.72MB / 68.72MB                                                                            4.8s
 => => sha256:48bbd1746d63c372e12f884178053851d87f3ea4b415f3d5e7d4eceb9aab6baf 124.14MB / 124.14MB                                                                          8.5s
 => => extracting sha256:0ecb575e629cd60aa802266a3bc6847dcf4073aa2a6d7d43f717dd61e7b90e0b                                                                                   2.5s
 => => sha256:944903612fdd2364b4647cf3c231c41103d1fd378add43fc85f6931f1d6a8276 126B / 126B                                                                                  3.8s
 => => extracting sha256:7467d1831b6947c294d92ee957902c3cd448b17c5ac2103ca5e79d15afb317c3                                                                                   0.3s
 => => extracting sha256:feab2c490a3cea21cc051ff29c33cc9857418edfa1be9966124b18abe1d5ae16                                                                                   0.2s
 => => extracting sha256:f15a0f46f8c38f4ca7daecf160ba9cdb3ddeafda769e2741e179851cfaa14eec                                                                                   3.3s
 => => extracting sha256:1517911a35d7939f446084c1d4c31afc552678e81b3450c2af998b57f72099c2                                                                                   3.3s
 => => extracting sha256:48bbd1746d63c372e12f884178053851d87f3ea4b415f3d5e7d4eceb9aab6baf                                                                                   4.6s
 => => extracting sha256:944903612fdd2364b4647cf3c231c41103d1fd378add43fc85f6931f1d6a8276                                                                                   0.0s
 => [2/5] RUN apt-get update && apt-get --yes install libseccomp-dev                                                                                                        6.6s
 => [3/5] RUN go version                                                                                                                                                    0.2s 
 => [4/5] RUN go get github.com/tools/godep                                                                                                                                 3.6s 
 => [5/5] RUN godep version                                                                                                                                                 0.2s 
 => exporting to image                                                                                                                                                      0.1s 
 => => exporting layers                                                                                                                                                     0.1s 
 => => writing image sha256:3d8a52e74a9fc0b8dde85ddb8ef730f06db43bb03857d6a338c037a36c1c4cd7                                                                                0.0s 
 => => naming to docker.io/library/autoscaling-builder                                                                                                                      0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/ autoscaling-builder:latest \
		bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && GO111MODULE=off go test -race ./... '
ok  	k8s.io/autoscaler/cluster-autoscaler	0.724s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider	0.133s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud	0.124s
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/credentials	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/signers	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/endpoints	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/errors	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/requests	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/responses	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/utils	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ecs	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ess	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/metadata	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws	0.902s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure	0.332s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud	0.198s
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bcc	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/billing	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/blb	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/cce	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/clientset	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/eip	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/vpc	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/clusterapi	10.353s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean	0.128s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce	0.742s
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud	0.283s
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/auth	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/auth/aksk	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/auth/token	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/internal	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/cce/v3/clusters	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/identity/v2/tenants	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/identity/v2/tokens	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/identity/v3/endpoints	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/identity/v3/services	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/identity/v3/tokens	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/openstack/utils	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/pagination	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/testhelper	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kubemark	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum	2.807s
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/fixtures	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/apiversions	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/v1/clusters	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/v1/nodegroups	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v2/tenants	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v2/tokens	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/extensions/trusts	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/tokens	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stackresources	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/utils	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mocks	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/packet	4.288s
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/clusterstate	0.166s
ok  	k8s.io/autoscaler/cluster-autoscaler/clusterstate/api	0.060s
ok  	k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils	0.165s
?   	k8s.io/autoscaler/cluster-autoscaler/config	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/config/dynamic	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/context	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/core	10.022s
ok  	k8s.io/autoscaler/cluster-autoscaler/core/utils	0.280s
ok  	k8s.io/autoscaler/cluster-autoscaler/estimator	0.262s
?   	k8s.io/autoscaler/cluster-autoscaler/expander	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/factory	0.176s
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/grpcplugin	0.165s
?   	k8s.io/autoscaler/cluster-autoscaler/expander/grpcplugin/example	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/expander/grpcplugin/protos	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/expander/mocks	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/mostpods	0.132s
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/price	0.176s
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/priority	0.114s
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/random	0.103s
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/waste	0.121s
ok  	k8s.io/autoscaler/cluster-autoscaler/metrics	0.364s
?   	k8s.io/autoscaler/cluster-autoscaler/processors	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/processors/callbacks	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset	0.356s
?   	k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfos	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/nodes	0.243s
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/pods	0.188s
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/status	0.311s
ok  	k8s.io/autoscaler/cluster-autoscaler/simulator	5.202s
?   	k8s.io/autoscaler/cluster-autoscaler/utils	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/backoff	3.103s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/daemonset	0.314s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint	0.262s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/drain	0.154s
?   	k8s.io/autoscaler/cluster-autoscaler/utils/errors	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/gpu	0.192s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/klogx	0.049s
?   	k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/labels	0.052s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/pod	0.060s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/scheduler	0.073s
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/taints	0.083s
?   	k8s.io/autoscaler/cluster-autoscaler/utils/test	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/tpu	0.043s
?   	k8s.io/autoscaler/cluster-autoscaler/utils/units	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/version	[no test files]
```

@drmorr0 @evansheng 