### PR TITLE
cluster autoscaler patch cluster autoscaler 1.24.0 airbnb0

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/OWNERS
+++ b/cluster-autoscaler/cloudprovider/gce/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- jayantjain93
+- maciekpytel
+- towca
+- x13n
+- yaroslava-serdiuk
+- BigDarkClown
+reviewers:
+- jayantjain93
+- maciekpytel
+- towca
+- x13n
+- yaroslava-serdiuk
+- BigDarkClown

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -169,4 +169,25 @@ type AutoscalingOptions struct {
 	DaemonSetEvictionForOccupiedNodes bool
 	// User agent to use for HTTP calls.
 	UserAgent string
+	// InitialNodeGroupBackoffDuration is the duration of first backoff after a new node failed to start
+	InitialNodeGroupBackoffDuration time.Duration
+	// MaxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start.
+	MaxNodeGroupBackoffDuration time.Duration
+	// NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.
+	NodeGroupBackoffResetTimeout time.Duration
+	// MaxScaleDownParallelism is the maximum number of nodes (both empty and needing drain) that can be deleted in parallel.
+	MaxScaleDownParallelism int
+	// MaxDrainParallelism is the maximum number of nodes needing drain, that can be drained and deleted in parallel.
+	MaxDrainParallelism int
+	// GceExpanderEphemeralStorageSupport is whether scale-up takes ephemeral storage resources into account.
+	GceExpanderEphemeralStorageSupport bool
+	// RecordDuplicatedEvents controls whether events should be duplicated within a 5 minute window.
+	RecordDuplicatedEvents bool
+	// MaxNodesPerScaleUp controls how many nodes can be added in a single scale-up.
+	// Note that this is strictly a performance optimization aimed at limiting binpacking time, not a tool to rate-limit
+	// scale-up. There is nothing stopping CA from adding MaxNodesPerScaleUp every loop.
+	MaxNodesPerScaleUp int
+	// MaxNodeGroupBinpackingDuration is a maximum time that can be spent binpacking a single NodeGroup. If the threshold
+	// is exceeded binpacking will be cut short and a partial scale-up will be performed.
+	MaxNodeGroupBinpackingDuration time.Duration
 }

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -113,7 +113,7 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 		opts.ExpanderStrategy = expanderStrategy
 	}
 	if opts.EstimatorBuilder == nil {
-		estimatorBuilder, err := estimator.NewEstimatorBuilder(opts.EstimatorName)
+		estimatorBuilder, err := estimator.NewEstimatorBuilder(opts.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(opts.MaxNodesPerScaleUp, opts.MaxNodeGroupBinpackingDuration))
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -169,7 +169,7 @@ func NewScaleTestAutoscalingContext(
 	}
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
-	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName)
+	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(0, 0))
 	predicateChecker, err := simulator.NewTestPredicateChecker()
 	if err != nil {
 		return context.AutoscalingContext{}, err

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -312,7 +312,7 @@ func computeExpansionOption(context *context.AutoscalingContext, podEquivalenceG
 
 	if len(option.Pods) > 0 {
 		estimator := context.EstimatorBuilder(context.PredicateChecker, context.ClusterSnapshot)
-		option.NodeCount = estimator.Estimate(option.Pods, nodeInfo)
+		option.NodeCount, option.Pods = estimator.Estimate(option.Pods, nodeInfo, option.NodeGroup)
 	}
 
 	return option, nil

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -357,7 +357,12 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		return nil
 	}
 
-	if a.deleteCreatedNodesWithErrors() {
+	danglingNodes, err := a.deleteCreatedNodesWithErrors()
+	if err != nil {
+		klog.Warningf("Failed to remove nodes that were created with errors, skipping iteration: %v", err)
+		return nil
+	}
+	if danglingNodes {
 		klog.V(0).Infof("Some nodes that failed to create were removed, skipping iteration")
 		return nil
 	}
@@ -656,7 +661,7 @@ func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNod
 	return removedAny, nil
 }
 
-func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() bool {
+func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 	// We always schedule deleting of incoming errornous nodes
 	// TODO[lukaszos] Consider adding logic to not retry delete every loop iteration
 	nodes := a.clusterStateRegistry.GetCreatedNodesWithErrors()
@@ -673,6 +678,9 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() bool {
 			}
 			klog.Warningf("Cannot determine nodeGroup for node %v; %v", id, err)
 			continue
+		}
+		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
+			return false, fmt.Errorf("node %s has no known nodegroup", node.GetName())
 		}
 		nodesToBeDeletedByNodeGroupId[nodeGroup.Id()] = append(nodesToBeDeletedByNodeGroupId[nodeGroup.Id()], node)
 	}
@@ -698,7 +706,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() bool {
 		a.clusterStateRegistry.InvalidateNodeInstancesCacheEntry(nodeGroup)
 	}
 
-	return deletedAny
+	return deletedAny, nil
 }
 
 func (a *StaticAutoscaler) nodeGroupsById() map[string]cloudprovider.NodeGroup {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1183,7 +1183,7 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
 	provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
 
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
+	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, newBackoff())
 	clusterState.RefreshCloudProviderNodeInstancesCache()
 	autoscaler.clusterStateRegistry = clusterState
 

--- a/cluster-autoscaler/estimator/binpacking_estimator_test.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator_test.go
@@ -22,6 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
@@ -30,89 +31,157 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func makePod(cpuPerPod, memoryPerPod int64) *apiv1.Pod {
-	return &apiv1.Pod{
+func makePods(cpuPerPod int64, memoryPerPod int64, hostport int32, maxSkew int32, topologySpreadingKey string, podCount int) []*apiv1.Pod {
+	pod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "estimatee",
+			Namespace: "universe",
+			Labels: map[string]string{
+				"app": "estimatee",
+			},
+		},
 		Spec: apiv1.PodSpec{
 			Containers: []apiv1.Container{
 				{
 					Resources: apiv1.ResourceRequirements{
 						Requests: apiv1.ResourceList{
 							apiv1.ResourceCPU:    *resource.NewMilliQuantity(cpuPerPod, resource.DecimalSI),
-							apiv1.ResourceMemory: *resource.NewQuantity(memoryPerPod, resource.DecimalSI),
+							apiv1.ResourceMemory: *resource.NewQuantity(memoryPerPod*units.MiB, resource.DecimalSI),
 						},
 					},
 				},
 			},
 		},
 	}
+	if hostport > 0 {
+		pod.Spec.Containers[0].Ports = []apiv1.ContainerPort{
+			{
+				HostPort: hostport,
+			},
+		}
+	}
+	if maxSkew > 0 {
+		pod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{
+			{
+				MaxSkew:           maxSkew,
+				TopologyKey:       topologySpreadingKey,
+				WhenUnsatisfiable: "DoNotSchedule",
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "estimatee",
+					},
+				},
+			},
+		}
+	}
+	pods := []*apiv1.Pod{}
+	for i := 0; i < podCount; i++ {
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
+func makeNode(cpu int64, mem int64, name string, zone string) *apiv1.Node {
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"kubernetes.io/hostname":      name,
+				"topology.kubernetes.io/zone": zone,
+			},
+		},
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceCPU:    *resource.NewMilliQuantity(cpu, resource.DecimalSI),
+				apiv1.ResourceMemory: *resource.NewQuantity(mem*units.MiB, resource.DecimalSI),
+				apiv1.ResourcePods:   *resource.NewQuantity(10, resource.DecimalSI),
+			},
+		},
+	}
+	node.Status.Allocatable = node.Status.Capacity
+	SetNodeReadyState(node, true, time.Time{})
+	return node
 }
 
 func TestBinpackingEstimate(t *testing.T) {
-	estimator := newBinPackingEstimator(t)
-
-	cpuPerPod := int64(350)
-	memoryPerPod := int64(1000 * units.MiB)
-	pod := makePod(cpuPerPod, memoryPerPod)
-
-	pods := make([]*apiv1.Pod, 0)
-	for i := 0; i < 10; i++ {
-		pods = append(pods, pod)
-	}
-	node := &apiv1.Node{
-		Status: apiv1.NodeStatus{
-			Capacity: apiv1.ResourceList{
-				apiv1.ResourceCPU:    *resource.NewMilliQuantity(cpuPerPod*3-50, resource.DecimalSI),
-				apiv1.ResourceMemory: *resource.NewQuantity(2*memoryPerPod, resource.DecimalSI),
-				apiv1.ResourcePods:   *resource.NewQuantity(10, resource.DecimalSI),
-			},
-		},
-	}
-	node.Status.Allocatable = node.Status.Capacity
-	SetNodeReadyState(node, true, time.Time{})
-
-	nodeInfo := schedulerframework.NewNodeInfo()
-	nodeInfo.SetNode(node)
-	estimate := estimator.Estimate(pods, nodeInfo)
-	assert.Equal(t, 5, estimate)
-}
-
-func TestBinpackingEstimateWithPorts(t *testing.T) {
-	estimator := newBinPackingEstimator(t)
-
-	cpuPerPod := int64(200)
-	memoryPerPod := int64(1000 * units.MiB)
-	pod := makePod(cpuPerPod, memoryPerPod)
-	pod.Spec.Containers[0].Ports = []apiv1.ContainerPort{
+	testCases := []struct {
+		name                 string
+		millicores           int64
+		memory               int64
+		maxNodes             int
+		pods                 []*apiv1.Pod
+		topologySpreadingKey string
+		expectNodeCount      int
+		expectPodCount       int
+	}{
 		{
-			HostPort: 5555,
+			name:            "simple resource-based binpacking",
+			millicores:      350*3 - 50,
+			memory:          2 * 1000,
+			pods:            makePods(350, 1000, 0, 0, "", 10),
+			expectNodeCount: 5,
+			expectPodCount:  10,
+		},
+		{
+			name:            "pods-per-node bound binpacking",
+			millicores:      10000,
+			memory:          20000,
+			pods:            makePods(10, 100, 0, 0, "", 20),
+			expectNodeCount: 2,
+			expectPodCount:  20,
+		},
+		{
+			name:            "hostport conflict forces pod-per-node",
+			millicores:      1000,
+			memory:          5000,
+			pods:            makePods(200, 1000, 5555, 0, "", 8),
+			expectNodeCount: 8,
+			expectPodCount:  8,
+		},
+		{
+			name:            "limiter cuts binpacking",
+			millicores:      1000,
+			memory:          5000,
+			pods:            makePods(500, 1000, 0, 0, "", 20),
+			maxNodes:        5,
+			expectNodeCount: 5,
+			expectPodCount:  10,
+		},
+		{
+			name:            "hostname topology spreading with maxSkew=2 forces 2 pods/node",
+			millicores:      1000,
+			memory:          5000,
+			pods:            makePods(20, 100, 0, 2, "kubernetes.io/hostname", 8),
+			expectNodeCount: 4,
+			expectPodCount:  8,
+		},
+		{
+			name:            "zonal topology spreading with maxSkew=2 only allows 2 pods to schedule",
+			millicores:      1000,
+			memory:          5000,
+			pods:            makePods(20, 100, 0, 2, "topology.kubernetes.io/zone", 8),
+			expectNodeCount: 1,
+			expectPodCount:  2,
 		},
 	}
-	pods := make([]*apiv1.Pod, 0)
-	for i := 0; i < 8; i++ {
-		pods = append(pods, pod)
-	}
-	node := &apiv1.Node{
-		Status: apiv1.NodeStatus{
-			Capacity: apiv1.ResourceList{
-				apiv1.ResourceCPU:    *resource.NewMilliQuantity(5*cpuPerPod, resource.DecimalSI),
-				apiv1.ResourceMemory: *resource.NewQuantity(5*memoryPerPod, resource.DecimalSI),
-				apiv1.ResourcePods:   *resource.NewQuantity(10, resource.DecimalSI),
-			},
-		},
-	}
-	node.Status.Allocatable = node.Status.Capacity
-	SetNodeReadyState(node, true, time.Time{})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+			// Add one node in different zone to trigger topology spread constraints
+			clusterSnapshot.AddNode(makeNode(100, 100, "oldnode", "zone-jupiter"))
 
-	nodeInfo := schedulerframework.NewNodeInfo()
-	nodeInfo.SetNode(node)
-	estimate := estimator.Estimate(pods, nodeInfo)
-	assert.Equal(t, 8, estimate)
-}
+			predicateChecker, err := simulator.NewTestPredicateChecker()
+			assert.NoError(t, err)
+			limiter := NewThresholdBasedEstimationLimiter(tc.maxNodes, time.Duration(0))
+			estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter)
 
-func newBinPackingEstimator(t *testing.T) *BinpackingNodeEstimator {
-	predicateChecker, err := simulator.NewTestPredicateChecker()
-	clusterSnapshot := simulator.NewBasicClusterSnapshot()
-	assert.NoError(t, err)
-	estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot)
-	return estimator
+			node := makeNode(tc.millicores, tc.memory, "template", "zone-mars")
+			nodeInfo := schedulerframework.NewNodeInfo()
+			nodeInfo.SetNode(node)
+
+			estimatedNodes, estimatedPods := estimator.Estimate(tc.pods, nodeInfo, nil)
+			assert.Equal(t, tc.expectNodeCount, estimatedNodes)
+			assert.Equal(t, tc.expectPodCount, len(estimatedPods))
+		})
+	}
 }

--- a/cluster-autoscaler/estimator/threshold_based_limiter.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	klog "k8s.io/klog/v2"
+)
+
+type thresholdBasedEstimationLimiter struct {
+	maxDuration time.Duration
+	maxNodes    int
+	nodes       int
+	start       time.Time
+}
+
+func (tbel *thresholdBasedEstimationLimiter) StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup) {
+	tbel.start = time.Now()
+	tbel.nodes = 0
+}
+
+func (*thresholdBasedEstimationLimiter) EndEstimation() {}
+
+func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode() bool {
+	if tbel.maxNodes > 0 && tbel.nodes >= tbel.maxNodes {
+		klog.V(4).Infof("Capping binpacking after exceeding threshold of %i nodes", tbel.maxNodes)
+		return false
+	}
+	timeDefined := tbel.maxDuration > 0 && tbel.start != time.Time{}
+	if timeDefined && time.Now().After(tbel.start.Add(tbel.maxDuration)) {
+		klog.V(4).Infof("Capping binpacking after exceeding max duration of %v", tbel.maxDuration)
+		return false
+	}
+	tbel.nodes++
+	return true
+}
+
+// NewThresholdBasedEstimationLimiter returns an EstimationLimiter that will prevent estimation
+// after either a node count- of time-based threshold is reached. This is meant to prevent cases
+// where binpacking of hundreds or thousands of nodes takes extremely long time rendering CA
+// incredibly slow or even completely crashing it.
+func NewThresholdBasedEstimationLimiter(maxNodes int, maxDuration time.Duration) EstimationLimiter {
+	return &thresholdBasedEstimationLimiter{
+		maxNodes:    maxNodes,
+		maxDuration: maxDuration,
+	}
+}

--- a/cluster-autoscaler/estimator/threshold_based_limiter_test.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type limiterOperation func(*testing.T, EstimationLimiter)
+
+func expectDeny(t *testing.T, l EstimationLimiter) {
+	assert.Equal(t, false, l.PermissionToAddNode())
+}
+
+func expectAllow(t *testing.T, l EstimationLimiter) {
+	assert.Equal(t, true, l.PermissionToAddNode())
+}
+
+func resetLimiter(t *testing.T, l EstimationLimiter) {
+	l.EndEstimation()
+	l.StartEstimation([]*apiv1.Pod{}, nil)
+}
+
+func TestThresholdBasedLimiter(t *testing.T) {
+	testCases := []struct {
+		name            string
+		maxNodes        int
+		maxDuration     time.Duration
+		startDelta      time.Duration
+		operations      []limiterOperation
+		expectNodeCount int
+	}{
+		{
+			name:     "no limiting happens",
+			maxNodes: 20,
+			operations: []limiterOperation{
+				expectAllow,
+				expectAllow,
+				expectAllow,
+			},
+			expectNodeCount: 3,
+		},
+		{
+			name:        "time based trigger fires",
+			maxNodes:    20,
+			maxDuration: 5 * time.Second,
+			startDelta:  -10 * time.Second,
+			operations: []limiterOperation{
+				expectDeny,
+				expectDeny,
+			},
+			expectNodeCount: 0,
+		},
+		{
+			name:     "sequence of additions works until the threshold is hit",
+			maxNodes: 3,
+			operations: []limiterOperation{
+				expectAllow,
+				expectAllow,
+				expectAllow,
+				expectDeny,
+			},
+			expectNodeCount: 3,
+		},
+		{
+			name:     "node counter is reset",
+			maxNodes: 2,
+			operations: []limiterOperation{
+				expectAllow,
+				expectAllow,
+				expectDeny,
+				resetLimiter,
+				expectAllow,
+			},
+			expectNodeCount: 1,
+		},
+		{
+			name:        "timer is reset",
+			maxNodes:    20,
+			maxDuration: 5 * time.Second,
+			startDelta:  -10 * time.Second,
+			operations: []limiterOperation{
+				expectDeny,
+				resetLimiter,
+				expectAllow,
+				expectAllow,
+			},
+			expectNodeCount: 2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			limiter := &thresholdBasedEstimationLimiter{
+				maxNodes:    tc.maxNodes,
+				maxDuration: tc.maxDuration,
+			}
+			limiter.StartEstimation([]*apiv1.Pod{}, nil)
+
+			if tc.startDelta != time.Duration(0) {
+				limiter.start = limiter.start.Add(tc.startDelta)
+			}
+
+			for _, op := range tc.operations {
+				op(t, limiter)
+			}
+			assert.Equal(t, tc.expectNodeCount, limiter.nodes)
+			limiter.EndEstimation()
+		})
+	}
+}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -187,9 +187,21 @@ var (
 	daemonSetEvictionForOccupiedNodes  = flag.Bool("daemonset-eviction-for-occupied-nodes", true, "DaemonSet pods will be gracefully terminated from non-empty nodes")
 	userAgent                          = flag.String("user-agent", "cluster-autoscaler", "User agent used for HTTP calls.")
 
-	emitPerNodeGroupMetrics  = flag.Bool("emit-per-nodegroup-metrics", false, "If true, emit per node group metrics.")
-	debuggingSnapshotEnabled = flag.Bool("debugging-snapshot-enabled", false, "Whether the debugging snapshot of cluster autoscaler feature is enabled")
-	nodeInfoCacheExpireTime  = flag.Duration("node-info-cache-expire-time", 87600*time.Hour, "Node Info cache expire time for each item. Default value is 10 years.")
+	emitPerNodeGroupMetrics         = flag.Bool("emit-per-nodegroup-metrics", false, "If true, emit per node group metrics.")
+	debuggingSnapshotEnabled        = flag.Bool("debugging-snapshot-enabled", false, "Whether the debugging snapshot of cluster autoscaler feature is enabled")
+	nodeInfoCacheExpireTime         = flag.Duration("node-info-cache-expire-time", 87600*time.Hour, "Node Info cache expire time for each item. Default value is 10 years.")
+	initialNodeGroupBackoffDuration = flag.Duration("initial-node-group-backoff-duration", 5*time.Minute,
+		"initialNodeGroupBackoffDuration is the duration of first backoff after a new node failed to start.")
+	maxNodeGroupBackoffDuration = flag.Duration("max-node-group-backoff-duration", 30*time.Minute,
+		"maxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start.")
+	nodeGroupBackoffResetTimeout = flag.Duration("node-group-backoff-reset-timeout", 3*time.Hour,
+		"nodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.")
+	maxScaleDownParallelismFlag        = flag.Int("max-scale-down-parallelism", 10, "Maximum number of nodes (both empty and needing drain) that can be deleted in parallel.")
+	maxDrainParallelismFlag            = flag.Int("max-drain-parallelism", 1, "Maximum number of nodes needing drain, that can be drained and deleted in parallel.")
+	gceExpanderEphemeralStorageSupport = flag.Bool("gce-expander-ephemeral-storage-support", false, "Whether scale-up takes ephemeral storage resources into account for GCE cloud provider")
+	recordDuplicatedEvents             = flag.Bool("record-duplicated-events", false, "enable duplication of similar events within a 5 minute window.")
+	maxNodesPerScaleUp                 = flag.Int("max-nodes-per-scaleup", 1000, "Max nodes added in a single scale-up. This is intended strictly for optimizing CA algorithm latency and not a tool to rate-limit scale-up throughput.")
+	maxNodeGroupBinpackingDuration     = flag.Duration("max-nodegroup-binpacking-duration", 10*time.Second, "Maximum time that will be spent in binpacking simulation for each NodeGroup.")
 )
 
 func createAutoscalingOptions() config.AutoscalingOptions {
@@ -269,6 +281,15 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		DaemonSetEvictionForEmptyNodes:     *daemonSetEvictionForEmptyNodes,
 		DaemonSetEvictionForOccupiedNodes:  *daemonSetEvictionForOccupiedNodes,
 		UserAgent:                          *userAgent,
+		InitialNodeGroupBackoffDuration:    *initialNodeGroupBackoffDuration,
+		MaxNodeGroupBackoffDuration:        *maxNodeGroupBackoffDuration,
+		NodeGroupBackoffResetTimeout:       *nodeGroupBackoffResetTimeout,
+		MaxScaleDownParallelism:            *maxScaleDownParallelismFlag,
+		MaxDrainParallelism:                *maxDrainParallelismFlag,
+		GceExpanderEphemeralStorageSupport: *gceExpanderEphemeralStorageSupport,
+		RecordDuplicatedEvents:             *recordDuplicatedEvents,
+		MaxNodesPerScaleUp:                 *maxNodesPerScaleUp,
+		MaxNodeGroupBinpackingDuration:     *maxNodeGroupBinpackingDuration,
 	}
 }
 


### PR DESCRIPTION
This PR is based off the upstream [1.24.0 release](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.24.0) and includes the following backports:

* https://github.com/kubernetes/autoscaler/pull/4970
* https://github.com/kubernetes/autoscaler/pull/5207
* https://github.com/kubernetes/autoscaler/pull/4926